### PR TITLE
Datasets QoL: Adding release notes to main Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Various speech datasets made available to the public.
 # Release Notes
 ## `202206`
 * `earnings-21`: Updated the some reference transcripts with some errors identified as part of our routine testing.
+    - Diff: +44 −45
+    - Modified 8 nlp files and 1 norm.json file
 * `earnings-22`: No changes since release of `202204`
 
 # Table of Contents

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Various speech datasets made available to the public.
 
 # Release Notes
-`202206`
-`earnings-21`: Updated the some reference transcripts with some errors identified as part of our routine testing.
-`earnings-22`: No changes since release of `202204`
+## `202206`
+* `earnings-21`: Updated the some reference transcripts with some errors identified as part of our routine testing.
+* `earnings-22`: No changes since release of `202204`
 
 # Table of Contents
 * [Datasets](#datasets)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Various speech datasets made available to the public.
 
+# Release Notes
+`202206`
+`earnings-21`: Updated the some reference transcripts with some errors identified as part of our routine testing.
+`earnings-22`: No changes since release of `202204`
+
 # Table of Contents
 * [Datasets](#datasets)
 * [How to Check Out Only a Single Dataset](#how-to-check-out-only-a-single-dataset)


### PR DESCRIPTION
We've recently decided to update our datasets and create new "release" versions to notify people of any major changes to the transcripts. This PR is the first to highlight those release tags.